### PR TITLE
Install ra10ke from rubygems.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,9 @@ RUN gem install --no-ri --no-rdoc r10k \
       puppetlabs_spec_helper \
       puppet-lint \
       onceover \
+      ra10ke \
       rest-client \
     && ln -s /usr/local/bundle/bin/* /usr/local/bin/
-
-## Install ra10ke from source until https://github.com/voxpupuli/ra10ke/issues/28
-## is released
-RUN git clone https://github.com/voxpupuli/ra10ke.git /tmp/ra10ke\
-    && cd /tmp/ra10ke \
-    && gem build ra10ke.gemspec \
-    && gem install ra10ke-0.4.0.gem
 
 COPY Rakefile /Rakefile
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,7 +3,7 @@
 SHA=''
 
 function build() {
-  SHA=$(docker build `pwd`/../ | grep "^Successfully built" | awk '{ print $3 }')
+  SHA=$(docker build "$(pwd)/../" | grep -qE "(^Successfully built|writing image sha256)" && docker images -q | head -n1)
   echo "Testing image with sha ${SHA}"
 }
 
@@ -35,14 +35,14 @@ function runtest() {
 
 build
 
-runtest 'Puppetfile with bad syntax' "docker run -v `pwd`/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile r10k:syntax" 1;
-runtest 'Puppetfile with good syntax' "docker run -v `pwd`/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile r10k:syntax" 0;
+runtest 'Puppetfile with bad syntax' "docker run -v $(pwd)/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile r10k:syntax" 1;
+runtest 'Puppetfile with good syntax' "docker run -v $(pwd)/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile r10k:syntax" 0;
 
-runtest 'Templates with bad syntax' "docker run -v `pwd`/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile syntax:templates" 1;
-runtest 'Templates with good syntax' "docker run -v `pwd`/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile syntax:templates" 0;
+runtest 'Templates with bad syntax' "docker run -v $(pwd)/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile syntax:templates" 1;
+runtest 'Templates with good syntax' "docker run -v $(pwd)/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile syntax:templates" 0;
 
-runtest 'Manifests with bad syntax' "docker run -v `pwd`/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile syntax:manifests" 1;
-runtest 'Manifests with good syntax' "docker run -v `pwd`/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile syntax:manifests" 0;
+runtest 'Manifests with bad syntax' "docker run -v $(pwd)/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile syntax:manifests" 1;
+runtest 'Manifests with good syntax' "docker run -v $(pwd)/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile syntax:manifests" 0;
 
-runtest 'Hiera with bad syntax' "docker run -v `pwd`/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile syntax:hiera" 1;
-runtest 'Hiera with good syntax' "docker run -v `pwd`/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile syntax:hiera" 0;
+runtest 'Hiera with bad syntax' "docker run -v $(pwd)/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile syntax:hiera" 1;
+runtest 'Hiera with good syntax' "docker run -v $(pwd)/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile syntax:hiera" 0;


### PR DESCRIPTION
* Install ra10ke from rubygems.org since <https://github.com/voxpupuli/ra10ke/issues/28> is resolved.
* Make `docker build` work either with or without Docker BuildKit (e.g., `DOCKER_BUILDKIT=1 docker build`)
* Shell-check fixes